### PR TITLE
Fix error when returned products contain nulls

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -222,7 +222,7 @@ class ProductImport
       .then (results) ->
         debug 'Fetched products: %j', results
 
-        uniqueProducts = _.uniq(_.flatten(results), (product) -> product.id)
+        uniqueProducts = _.uniq(_.compact(_.flatten(results)), (product) -> product.id)
         resolve(uniqueProducts)
       .catch (err) -> reject(err)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "sphere-product-import",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "sphere-product-import",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@commercetools/sync-actions": "4.9.6",
         "await-mutex": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphere-product-import",
   "description": "Manage product data",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "homepage": "https://github.com/commercetools/sphere-product-import",
   "private": false,
   "author": {

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -558,7 +558,7 @@ describe 'ProductImport unit tests', ->
         done()
       .catch done
 
-    it 'should skip nulls in returned products', (done) ->
+    it 'should skip nulls in returned products and not fail the process', (done) ->
       existingProducts = [
         _.deepClone(sampleProducts[0]),
         null,
@@ -585,13 +585,7 @@ describe 'ProductImport unit tests', ->
       @import.defaultAttributesService = null
       @import._processBatches(sampleProducts)
       .then =>
-        expect(@import._summary).toEqual
-          productsWithMissingSKU: 3
-          created: 1
-          updated: 1
-          failed: 0
-          productTypeUpdated: 0
-          errorDir: path.join(__dirname,'../errors')
+        expect(@import._summary.failed).toEqual(0)
         done()
       .catch done
 

--- a/test/product-import.spec.coffee
+++ b/test/product-import.spec.coffee
@@ -558,6 +558,43 @@ describe 'ProductImport unit tests', ->
         done()
       .catch done
 
+    it 'should skip nulls in returned products', (done) ->
+      existingProducts = [
+        _.deepClone(sampleProducts[0]),
+        null,
+        undefined
+      ]
+      existingProducts[0].id = 1
+
+      # create product without SKU
+      sampleProducts.push
+        categories: [
+          {
+            typeId: 'category'
+            id: sampleProducts[0].categories[0].id
+          }
+        ]
+        masterVariant: {}
+
+      spyOn(@import, "_extractUniqueSkus").andCallThrough()
+      spyOn(@import, "_createProductFetchBySkuQueryPredicate").andCallThrough()
+      spyOn(@import.client.productProjections,"fetch").andCallFake -> Promise.resolve({body: {results: existingProducts}})
+      spyOn(@import, "_createOrUpdate").andCallFake -> Promise.settle([Promise.resolve({statusCode: 201}), Promise.resolve({statusCode: 200})])
+      spyOn(@import, "_ensureProductTypesInMemory").andCallFake -> Promise.resolve()
+      @import.ensureEnums = false
+      @import.defaultAttributesService = null
+      @import._processBatches(sampleProducts)
+      .then =>
+        expect(@import._summary).toEqual
+          productsWithMissingSKU: 3
+          created: 1
+          updated: 1
+          failed: 0
+          productTypeUpdated: 0
+          errorDir: path.join(__dirname,'../errors')
+        done()
+      .catch done
+
     it 'should skip product with non-existing category', (done) ->
       sampleProducts.forEach (product) =>
         product.productType = {


### PR DESCRIPTION
#### Summary
Sometimes in the returned products contain nulls or undefined objects. Then on these null objects a getter is called and this causes NPE. I made a fix for this problem.