### PR TITLE
Add retry when resolving references

### DIFF
--- a/lib/product-import.coffee
+++ b/lib/product-import.coffee
@@ -723,7 +723,7 @@ class ProductImport
         request = service.where(predicate)
         if refKey is 'product'
           request.staged(true)
-        @_fetchReference(request, refKey, ref, predicate,)
+        @_fetchReference(request, refKey, ref, predicate, 0)
         .then (results) =>
           @_cache[refKey][ref.id] = results[0]
           @_cache[refKey][results[0].id] = results[0]
@@ -748,6 +748,6 @@ class ProductImport
             if (_.isArray(result.body.results))
               return result.body.results
             else
-              @_fetchReference(request, refKey, ref, predicate, count++)
+              @_fetchReference(request, refKey, ref, predicate, count + 1)
 
 module.exports = ProductImport

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "sphere-product-import",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "dependencies": {
         "@commercetools/sync-actions": "4.9.6",
         "await-mutex": "1.0.2",

--- a/test/integration.spec.coffee
+++ b/test/integration.spec.coffee
@@ -372,7 +372,7 @@ describe 'Product import integration tests', ->
     @import.errorCallback = (err, logger) ->
       errorLogger = logger
       errorCount += 1
-      error = err.toString()
+      error = err.message.toString()
 
     @import._processBatches([product])
     .then =>


### PR DESCRIPTION
When [resolving references](https://github.com/commercetools/sphere-product-import/blob/c02829254002eb3ffc0bcd554b5cc46833949db9/lib/product-import.coffee#L734), sometimes it returns Stringified JSON and this is not expected result. This causes the process to fail.

As this happens rarely and on retry it usually works, I added a retry.